### PR TITLE
Button to "attach" to a game and skip the steam console

### DIFF
--- a/SteamP2PInfo/MainWindow.xaml.cs
+++ b/SteamP2PInfo/MainWindow.xaml.cs
@@ -204,9 +204,8 @@ namespace SteamP2PInfo
                     }
 
                     wInfo = dialog.SelectedWindow;
-                    bool skipSteamConsole = dialog.skipSteamConsole;
                     SteamPeerManager.Init();
-                    if(!skipSteamConsole)
+                    if(!dialog.skipSteamConsole)
                         SteamConsoleHelper();
 
                     HotkeyManager.RemoveHotkey(overlayHotkey);

--- a/SteamP2PInfo/MainWindow.xaml.cs
+++ b/SteamP2PInfo/MainWindow.xaml.cs
@@ -204,8 +204,10 @@ namespace SteamP2PInfo
                     }
 
                     wInfo = dialog.SelectedWindow;
+                    bool skipSteamConsole = dialog.skipSteamConsole;
                     SteamPeerManager.Init();
-                    SteamConsoleHelper();
+                    if(!skipSteamConsole)
+                        SteamConsoleHelper();
 
                     HotkeyManager.RemoveHotkey(overlayHotkey);
                     overlayHotkey = HotkeyManager.AddHotkey(wInfo.Handle, () => GameConfig.Current.OverlayConfig.Hotkey, () => GameConfig.Current.OverlayConfig.Enabled ^= true);

--- a/SteamP2PInfo/WindowSelectDialog.xaml
+++ b/SteamP2PInfo/WindowSelectDialog.xaml
@@ -22,10 +22,11 @@
         </Grid.ColumnDefinitions>
         <ScrollViewer Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="5">
             <ListBox Name="WindowListBox" MouseDoubleClick="WindowListBox_MouseDoubleClick" SelectionChanged="WindowListBox_SelectionChanged">
-                
+
             </ListBox>
         </ScrollViewer>
-        <Button Grid.Row="1" Grid.Column="0" Margin="5" Click="OpenButton_Click" IsEnabled="False" Name="btnOpen">Open</Button>
-        <Button Grid.Row="1" Grid.Column="1" Margin="5" Click="CancelButton_Click">Cancel</Button>
+        <Button Grid.Row="1" Grid.Column="0" Margin="5,5,5,42" Click="OpenButton_Click" IsEnabled="False" Name="btnOpen">Open</Button>
+        <Button Grid.Row="1" Grid.Column="0" Margin="5,37,5,10" Click="OpenImmButton_Click" IsEnabled="False" Name="btnOpenImm">Open immediately</Button>
+        <Button Grid.Row="1" Grid.Column="1" Margin="5,24,5,23" Click="CancelButton_Click">Cancel</Button>
     </Grid>
 </mah:MetroWindow>

--- a/SteamP2PInfo/WindowSelectDialog.xaml
+++ b/SteamP2PInfo/WindowSelectDialog.xaml
@@ -26,7 +26,7 @@
             </ListBox>
         </ScrollViewer>
         <Button Grid.Row="1" Grid.Column="0" Margin="5,5,5,42" Click="OpenButton_Click" IsEnabled="False" Name="btnOpen">Open</Button>
-        <Button Grid.Row="1" Grid.Column="0" Margin="5,37,5,10" Click="OpenImmButton_Click" IsEnabled="False" Name="btnOpenImm">Open immediately</Button>
+        <Button Grid.Row="1" Grid.Column="0" Margin="5,37,5,10" FontSize="11" Click="OpenSkipConsoleButton_Click" IsEnabled="False" Name="btnOpenSkipConsole">Open (skip Steam console)</Button>
         <Button Grid.Row="1" Grid.Column="1" Margin="5,24,5,23" Click="CancelButton_Click">Cancel</Button>
     </Grid>
 </mah:MetroWindow>

--- a/SteamP2PInfo/WindowSelectDialog.xaml.cs
+++ b/SteamP2PInfo/WindowSelectDialog.xaml.cs
@@ -78,7 +78,7 @@ namespace SteamP2PInfo
             DialogResult = true;
         }
 
-        private void OpenImmButton_Click(object sender, RoutedEventArgs e)
+        private void OpenSkipConsoleButton_Click(object sender, RoutedEventArgs e)
         {
             SelectedWindow = windows[WindowListBox.SelectedIndex];
             skipSteamConsole = true;
@@ -93,7 +93,7 @@ namespace SteamP2PInfo
         private void WindowListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             btnOpen.IsEnabled = true;
-            btnOpenImm.IsEnabled = true;
+            btnOpenSkipConsole.IsEnabled = true;
         }
     }
 }

--- a/SteamP2PInfo/WindowSelectDialog.xaml.cs
+++ b/SteamP2PInfo/WindowSelectDialog.xaml.cs
@@ -33,6 +33,7 @@ namespace SteamP2PInfo
 
         private List<WindowInfo> windows = new List<WindowInfo>();
         public WindowInfo SelectedWindow = null;
+        public bool skipSteamConsole = false;
 
         public WindowSelectDialog()
         {
@@ -77,6 +78,13 @@ namespace SteamP2PInfo
             DialogResult = true;
         }
 
+        private void OpenImmButton_Click(object sender, RoutedEventArgs e)
+        {
+            SelectedWindow = windows[WindowListBox.SelectedIndex];
+            skipSteamConsole = true;
+            DialogResult = true;
+        }
+
         private void CancelButton_Click(object sender, RoutedEventArgs e)
         {
             DialogResult = false;
@@ -85,6 +93,7 @@ namespace SteamP2PInfo
         private void WindowListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             btnOpen.IsEnabled = true;
+            btnOpenImm.IsEnabled = true;
         }
     }
 }


### PR DESCRIPTION
I made this for when you've already used the command in the steam console in the same "session" so you don't want for the steam console to open again just to close it.