### PR TITLE
Rewrite to work with `log_ipc "BeginAuthSession,EndAuthSession"`

### DIFF
--- a/SteamP2PInfo/SteamP2PInfo.csproj
+++ b/SteamP2PInfo/SteamP2PInfo.csproj
@@ -280,6 +280,7 @@
     <Compile Include="OverlayWindow.xaml.cs">
       <DependentUpon>OverlayWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="SteamPeerInfo.cs" />
     <Compile Include="SteamPeerNewAPI.cs" />
     <Compile Include="SteamPeerOldAPI.cs" />
     <Compile Include="SteamPeerManager.cs" />

--- a/SteamP2PInfo/SteamPeerInfo.cs
+++ b/SteamP2PInfo/SteamPeerInfo.cs
@@ -1,0 +1,21 @@
+﻿namespace SteamP2PInfo
+{
+    internal class SteamPeerInfo
+    {
+        internal SteamPeerBase steamPeerBase;
+        internal DisconnectReason disconnectReason;
+
+        internal SteamPeerInfo(SteamPeerBase steamPeerBase)
+        {
+            this.steamPeerBase = steamPeerBase;
+            disconnectReason = DisconnectReason.NONE;
+        }
+
+        internal enum DisconnectReason
+        {
+            NONE,
+            AUTH_SESSION_ENDED,
+            PEER_DISCONNECTED,
+        }
+    }
+}


### PR DESCRIPTION
## The Problem

This changes SteamP2PInfo to work on `log_ipc "BeginAuthSession,EndAuthSession"` logs instead of the current `log_ipc IClientMatchmaking` logs. This fixes #30, and possibly fixes #17.

The issue is that in some games (I did all my testing under Armored Core 6) lobby IDs are only emitted by IClientMatchmaking logs if you're _not_ the host, which unfortunately for 1v1 matches is 50% failure rate.

## The Fix

I observed that IClientUser BeginAuthSession and EndAuthSession logs reliably contain the other client's Steam3 ID, so I adapted SteamPeerManager.cs to use those logs instead. I've included some example log output below (with numbers altered to project the innocent person I just 1v1'd).

```log
4234570 armoredcore6.exe:262147 > IClientUser::BeginAuthSession( 246, [U:1:123456789], 246 bytes [00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ... 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 008], ) = 0, 
04491448 armoredcore6.exe:262147 > IClientUser::EndAuthSession( [U:1:123456789], )
```

## If you want to use this fix today

As per [this comment](https://github.com/tremwil/SteamP2PInfo/issues/31#issuecomment-1595873401), @tremwil says:

> Note that I'm also working on other projects at the moment and am not considering feature additions for SteamP2PInfo, so the best course of action if you really want a ping filter is probably to clone the project, do the research and add it for yourself.

So I'm unsure if this PR will ever be merged. Despite that, I still believe it's good practice to open a PR to the source repo; if the project ever resumes development it's nice to have, and it leaves a record of the fix here.

If you want to use the my fixed version today I have a build available at my fork: https://github.com/zkxs/SteamP2PInfo. It works for me reliably in Armored Core 6, but I haven't tested it with any other games.